### PR TITLE
Bug fix with zero size message

### DIFF
--- a/app/Test.hs
+++ b/app/Test.hs
@@ -115,7 +115,9 @@ testAction3 rpp = do
 
 -- NOTE: `() -> M ()` cause the following error:
 -- "Network.Socket.recvBuf: invalid argument (non-positive length)"
--- TODO: investigate this.
+-- it's due because no data is serialized:
+--  http://hackage.haskell.org/package/binary-0.10.0.0/docs/src/Data.Binary.Class.html#line-183
+-- TODO: handle 0-byte serialization as a special case.
 closure1 :: Closure (() -> M Int)
 closure1 = static (\() -> testAction >> pure 0)
 

--- a/app/Test.hs
+++ b/app/Test.hs
@@ -49,6 +49,9 @@ import Control.Distributed.Playground.Request ( Request
                                               , requestToM
                                               )
 
+instance StaticSomeRequest (Request () ()) where
+  staticSomeRequest _ = static (SomeRequest <$> (get :: Get (Request () ())))
+
 instance StaticSomeRequest (Request () Int) where
   staticSomeRequest _ = static (SomeRequest <$> (get :: Get (Request () Int)))
 
@@ -113,22 +116,17 @@ testAction3 rpp = do
   result <- receiveChan (rp2pPort rp2p)
   logText $ "received from p2p: " <> T.pack (show result)
 
--- NOTE: `() -> M ()` cause the following error:
--- "Network.Socket.recvBuf: invalid argument (non-positive length)"
--- it's due because no data is serialized:
---  http://hackage.haskell.org/package/binary-0.10.0.0/docs/src/Data.Binary.Class.html#line-183
--- TODO: handle 0-byte serialization as a special case.
-closure1 :: Closure (() -> M Int)
-closure1 = static (\() -> testAction >> pure 0)
+closure1 :: Closure (() -> M ())
+closure1 = static (\() -> testAction)
 
-closure2 :: SendP2PProto Int -> Closure (() -> M Int)
+closure2 :: SendP2PProto Int -> Closure (() -> M ())
 closure2 sp2p =
-  static (\(SProtoInt sp) () -> testAction2 sp >> pure 0)
+  static (\(SProtoInt sp) () -> testAction2 sp)
   `staticMap` cpure closureDict (SProtoInt sp2p)
 
-closure3 :: RecvP2PProto Int -> Closure (() -> M Int)
+closure3 :: RecvP2PProto Int -> Closure (() -> M ())
 closure3 rp2p = do
-  static (\(RProtoInt rp) () -> testAction3 rp >> pure 0)
+  static (\(RProtoInt rp) () -> testAction3 rp)
   `staticMap` cpure closureDict (RProtoInt rp2p)
 
 
@@ -168,7 +166,7 @@ initPass toNextP = do
   toNext <- getSendP2P toNextP
   let baton = 0
   logText $ "start a baton with value: " <> T.pack (show baton)
-  sendChan (sp2pPort toNext)  baton
+  sendChan (sp2pPort toNext) baton
 
 finalPass :: RecvP2PProto Int -> M Int
 finalPass fromPrevP = do
@@ -189,9 +187,9 @@ relayer fromPrevP toNextP = do
   sendChan (sp2pPort toNext) (baton+1)
 
 
-clsr_initPass :: SendP2PProto Int -> Closure (() -> M Int)
+clsr_initPass :: SendP2PProto Int -> Closure (() -> M ())
 clsr_initPass toNextP =
-  static (\(SProtoInt sp) () -> initPass sp >> pure 0)
+  static (\(SProtoInt sp) () -> initPass sp)
   `staticMap` cpure closureDict (SProtoInt toNextP)
 
 clsr_finalPass :: RecvP2PProto Int -> Closure (() -> M Int)
@@ -199,11 +197,23 @@ clsr_finalPass fromPrevP =
   static (\(RProtoInt rp) () -> finalPass rp)
   `staticMap` cpure closureDict (RProtoInt fromPrevP)
 
-clsr_relayer :: RecvP2PProto Int -> SendP2PProto Int -> Closure (() -> M Int)
+clsr_relayer :: RecvP2PProto Int -> SendP2PProto Int -> Closure (() -> M ())
 clsr_relayer fromPrevP toNextP =
-  static (\(RProtoInt rp) (SProtoInt sp) () -> relayer rp sp >> pure 0)
+  static (\(RProtoInt rp) (SProtoInt sp) () -> relayer rp sp)
   `staticMap` cpure closureDict (RProtoInt fromPrevP)
   `staticMap` cpure closureDict (SProtoInt toNextP)
+
+numPlayer :: Int
+numPlayer = 4
+
+nthSlave :: Int -> NodeName
+nthSlave n = NodeName $ "slave" <> (T.pack (show n))
+
+initSlave :: NodeName
+initSlave = nthSlave 0
+
+lastSlave :: NodeName
+lastSlave = nthSlave numPlayer
 
 
 -- | relaying test
@@ -211,18 +221,18 @@ relay :: M ()
 relay = do
   liftIO $ threadDelay 1000000
 
-  chs <- replicateM 4 newP2P
+  chs <- replicateM numPlayer newP2P
   let sps = map fst chs -- send ports
       rps = map snd chs -- receive ports
       sp0 = head sps
       rpn = last rps
   let pairs = zip rps (tail sps)  -- (r_i,s_(i+1))
-      nodes = map NodeName ["slave1","slave2","slave3"]
+      nodes = map nthSlave [1..numPlayer-1]
   as <- for (zip pairs nodes) $ \((rpp,spp),node) -> do
           a <- async $ requestToM node (clsr_relayer rpp spp) [()]
           pure a
-  a0 <- async $ requestToM (NodeName "slave0") (clsr_initPass sp0) [()]
-  an <- async $ requestToM (NodeName "slave4") (clsr_finalPass rpn) [()]
+  a0 <- async $ requestToM initSlave (clsr_initPass sp0) [()]
+  an <- async $ requestToM lastSlave (clsr_finalPass rpn) [()]
 
   _ <- wait a0
   traverse_ wait as

--- a/src/Control/Distributed/Playground/Comm.hs
+++ b/src/Control/Distributed/Playground/Comm.hs
@@ -29,7 +29,7 @@ import Control.Monad.Trans.Maybe (MaybeT(..))
 import Control.Monad.Trans.Reader (ReaderT(runReaderT),ask)
 import Control.Monad.Trans.State (runStateT)
 import qualified Control.Monad.Trans.State as S
-import Data.Binary (Binary(get,put), decode, encode)
+import Data.Binary (Binary, decode, encode)
 import Data.Binary.Get (getWord32le,runGet)
 import Data.Binary.Put (putWord32le,runPut)
 import qualified Data.ByteString as B
@@ -47,12 +47,6 @@ import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Network.Simple.TCP (Socket, SockAddr, recv, send)
 import UnliftIO.Concurrent (forkIO)
-
-data BinProxy a = BinProxy
-
-instance Binary (BinProxy a) where
-  put BinProxy = mempty
-  get          = pure BinProxy
 
 -------------
 -- Message --

--- a/src/Control/Distributed/Playground/Comm.hs
+++ b/src/Control/Distributed/Playground/Comm.hs
@@ -21,7 +21,7 @@ import Control.Concurrent.STM ( TChan
                               , writeTChan
                               )
 import Control.Concurrent.STM.TQueue (TQueue,newTQueueIO,readTQueue,writeTQueue)
-import Control.Monad (forever, void)
+import Control.Monad ( forever, void, when )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Loops (whileJust_)
 import Control.Monad.Trans.Class (lift)
@@ -72,14 +72,22 @@ recvMsg sock =
   runMaybeT $ do
     !bs <- MaybeT $ recv sock 4
     let sz = runGet getWord32le (BL.fromStrict bs)
-    !bs' <- MaybeT $ recv sock (fromIntegral sz)
-    pure $! Msg sz bs'
+    if sz > 0
+      then do
+        !bs' <- MaybeT $ recv sock (fromIntegral sz)
+        pure $! Msg sz bs'
+      else
+        -- Zero length message should be treated specially.
+        -- Otherwise, the following error happens.
+        -- "Network.Socket.recvBuf: invalid argument (non-positive length)"
+        pure $! Msg sz ""
 
 sendMsg :: Socket -> Msg -> IO ()
 sendMsg sock (Msg sz pl) = do
   let !lbs = runPut (putWord32le sz)
   send sock (BL.toStrict lbs)
-  send sock pl
+  when (sz > 0) $
+    send sock pl
 
 -- | message with target id
 data IMsg = IMsg { imsgReceiver :: !Word32
@@ -94,8 +102,15 @@ recvIMsg sock = do
     let i = runGet getWord32le (BL.fromStrict bs1)
     !bs2 <- MaybeT $ recv sock 4
     let sz = runGet getWord32le (BL.fromStrict bs2)
-    !payload <- MaybeT $ recv sock (fromIntegral sz)
-    pure $! IMsg i (Msg sz payload)
+    if sz > 0
+      then do
+        !payload <- MaybeT $ recv sock (fromIntegral sz)
+        pure $! IMsg i (Msg sz payload)
+      else
+        -- Zero length message should be treated specially.
+        -- Otherwise, the following error happens.
+        -- "Network.Socket.recvBuf: invalid argument (non-positive length)"
+        pure $! IMsg i (Msg sz "")
 
 
 sendIMsg :: Socket -> IMsg -> IO ()
@@ -104,7 +119,8 @@ sendIMsg sock (IMsg i (Msg sz pl)) = do
   send sock (BL.toStrict lb_i)
   let !lb_sz = runPut (putWord32le sz)
   send sock (BL.toStrict lb_sz)
-  send sock pl
+  when (sz > 0) $
+    send sock pl
 
 -------------
 -- Managed --


### PR DESCRIPTION
The error ` "Network.Socket.recvBuf: invalid argument (non-positive length)"` when using unit type for result was due to zero-length encoding of `Binary ()`. I treat the zero-length case specially.